### PR TITLE
bug: perl engine tries to execute manifest.path which gets set to ../spool/app_name and is a directory

### DIFF
--- a/perl/perl.cpp
+++ b/perl/perl.cpp
@@ -66,7 +66,13 @@ public:
             throw configuration_error_t("malformed manifest");
         }
 
+        Json::Value script_file = args["script-file"];
+        if (!script_file.isString()) {
+            throw configuration_error_t("malformed manifest, expected args script-file to be a name of the perl script to run");
+        }
+
         boost::filesystem::path source(manifest.path);
+        source/=script_file.asString();
 
         if(boost::filesystem::is_directory(source)) {
             throw configuration_error_t("malformed manifest, expected path to perl script, got a directory.");   


### PR DESCRIPTION
Hi,

There seems to be a bug in perl plugin, 

perl.cpp:
boost::filesystem::path source(manifest.path);
if(boost::filesystem::is_directory(source)) {
            throw configuration_error_t("malformed manifest, expected path to perl script, got a directory.");  
}

it throws always, since manifest.path is set to ../spool/app_name in manifest_t::deploy() which is a directory.

proposed change:

add a 'script-file' required key to manifest.args for perl apps. 
which should be set to the name of the perl script inside the app package.

Thanks!
