### PR TITLE
memory leak in python/io.cpp

### DIFF
--- a/python/io.cpp
+++ b/python/io.cpp
@@ -45,7 +45,7 @@ void python_io_t::destructor(python_io_t * self) {
     self->ob_type->tp_free(self);
     
     if(!self->request.empty()){
-        static cocaine::blob_t dummy("dummyValue", strlen("dummyValue"));
+        static cocaine::blob_t dummy("d", 2);
         self->request = dummy;
         self->request.clear();
     }


### PR DESCRIPTION
Hi again,

There is a memory leak in plugins/python/io.cpp

Since python_io_t implicit cpp destructor is not called when
invoking python_io_t::destructor

the blob_t python_io_t::request destructor is not called either.
blob_t contains a shared_ptr<reference_counter> m_ref_counter,
and so its destructor is not called also.

which results in hanging reference_counter instance (memory leak)

The proposed solution:
in python_io_t::destructor
assign self->request to some dummy static non empy blob_t to cause m_ref_counter.reset() which would destroy the hanging reference_counter.

Another solution could be modifying blob_t::clear() method to reset m_ref_counter, but it seems unnatural
to change blob_t because of python issues.

Thanks,
Vladimir Shakhov (bogdad@gmail.com)
