### PR TITLE
Postinst for IPVS plugin.

### DIFF
--- a/debian/libcocaine-plugin-ipvs2.postinst
+++ b/debian/libcocaine-plugin-ipvs2.postinst
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+    if [ $(grep -c ip_vs /etc/modules) -eq 0 ] ; then
+        echo "ip_vs" >> /etc/modules
+    fi
+    ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0
+
+#DEBHELPER#


### PR DESCRIPTION
Added postinst for libcocaine-plugin-ipvs2, which adds ip_vs module to /etc/modules.
