### PR TITLE
[Mongo] Disable mongo plugin in control.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,14 +59,14 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-core3 (>= 0.12.0.0), lib
 Description: Cocaine - IPVS Gateway
  IP Virtual Service Gateway for Cocaine.
 
-Package: libcocaine-plugin-mongodb3
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-core3 (>= 0.12.0.0),
- libmongoclient | mongodb-clients
-Provides: cocaine-plugin-mongodb
-Replaces: cocaine-plugin-mongodb
-Description: Cocaine - MongoDB Storage
- MongoDB storage support for Cocaine.
+#Package: libcocaine-plugin-mongodb3
+#Architecture: any
+#Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-core3 (>= 0.12.0.0),
+# libmongoclient | mongodb-clients
+#Provides: cocaine-plugin-mongodb
+#Replaces: cocaine-plugin-mongodb
+#Description: Cocaine - MongoDB Storage
+# MongoDB storage support for Cocaine.
 
 Package: libcocaine-plugin-urlfetch3
 Architecture: any


### PR DESCRIPTION
This plugin is disabled even in CMakeLists, so it must be disabled
in debian/control to not affect a building of deb. package. When this plugin is fixed, we'll turn it on.
