### PR TITLE
[Docker] Backport from 0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.0.3) unstable; urgency=low
+
+  * [Docker] Port network_mode and capabilities from v0.11
+  * [Docker] Fix a possible corruption of a socket path 
+
+ -- Anton Tyurin <noxiouz@yandex.ru>  Wed, 18 Mar 2015 12:29:07 +0300
+
 cocaine-plugins (0.12.0.2) unstable; urgency=low
 
   * Update Blackhole version to be able to link with the runtime.

--- a/docker/docker_client.cpp
+++ b/docker/docker_client.cpp
@@ -633,7 +633,7 @@ client_impl_t::head(http_response_t& response,
 }
 
 namespace {
-    std::string api_version = "/v1.4";
+    std::string api_version = "/v1.14";
 
     http_request_t
     make_post(const std::string& url,
@@ -685,7 +685,7 @@ container_t::start(const std::vector<std::string>& binds) {
     http_response_t resp;
     m_client->post(resp, make_post(api_version + cocaine::format("/containers/%s/start", id()), args));
 
-    if(!(resp.code() >= 200 && resp.code() < 300)) {
+    if(!(resp.code() >= 200 && resp.code() < 400)) {
         COCAINE_LOG_WARNING(m_logger,
                             "Unable to start container %s. Docker replied with code %d and body '%s'.",
                             id(),
@@ -700,7 +700,7 @@ container_t::kill() {
     http_response_t resp;
     m_client->post(resp, make_post(api_version + cocaine::format("/containers/%s/kill", id())));
 
-    if(!(resp.code() >= 200 && resp.code() < 300)) {
+    if(!(resp.code() >= 200 && resp.code() < 400)) {
         COCAINE_LOG_WARNING(m_logger,
                             "Unable to kill container %s. Docker replied with code %d and body '%s'.",
                             id(),
@@ -715,7 +715,7 @@ container_t::stop(unsigned int timeout) {
     http_response_t resp;
     m_client->post(resp, make_post(api_version + cocaine::format("/containers/%s/stop?t=%d", id(), timeout)));
 
-    if(!(resp.code() >= 200 && resp.code() < 300)) {
+    if(!(resp.code() >= 200 && resp.code() < 400)) {
         COCAINE_LOG_WARNING(m_logger,
                             "Unable to stop container %s. Docker replied with code %d and body '%s'.",
                             id(),

--- a/docker/docker_client.cpp
+++ b/docker/docker_client.cpp
@@ -669,19 +669,7 @@ namespace {
 }
 
 void
-container_t::start(const std::vector<std::string>& binds) {
-    rapidjson::Value args;
-    rapidjson::Value b;
-    rapidjson::Value::AllocatorType allocator;
-
-    b.SetArray();
-    for(auto it = binds.begin(); it != binds.end(); ++it) {
-        b.PushBack(it->data(), allocator);
-    }
-
-    args.SetObject();
-    args.AddMember("Binds", b, allocator);
-
+container_t::start(const rapidjson::Value& args) {
     http_response_t resp;
     m_client->post(resp, make_post(api_version + cocaine::format("/containers/%s/start", id()), args));
 

--- a/docker/docker_client.hpp
+++ b/docker/docker_client.hpp
@@ -171,7 +171,7 @@ public:
     }
 
     void
-    start(const std::vector<std::string>& binds = std::vector<std::string>());
+    start(const rapidjson::Value& args);
 
     void
     kill();

--- a/docker/isolate.cpp
+++ b/docker/isolate.cpp
@@ -135,6 +135,8 @@ docker_t::docker_t(context_t& context, const std::string& name, const dynamic_t&
         m_image += name;
         m_tag = ""; // empty for now
 
+        m_network_mode = config.at("network_mode", "bridge").as_string();
+
         m_run_config.SetObject();
 
         m_run_config.AddMember("Hostname", "", m_json_allocator);
@@ -163,6 +165,7 @@ docker_t::docker_t(context_t& context, const std::string& name, const dynamic_t&
         m_run_config["Volumes"].AddMember(m_runtime_path.c_str(), empty_object, m_json_allocator);
         m_run_config.AddMember("VolumesFrom", "", m_json_allocator);
         m_run_config.AddMember("WorkingDir", "/", m_json_allocator);
+        m_run_config.AddMember("NetworkMode", m_network_mode.data(), m_json_allocator);
     } catch(const std::exception& e) {
         throw cocaine::error_t("%s", e.what());
     }

--- a/docker/isolate.cpp
+++ b/docker/isolate.cpp
@@ -61,8 +61,8 @@ struct container_handle_t:
     }
 
     void
-    start(const std::vector<std::string>& binds) {
-        m_container.start(binds);
+    start(const rapidjson::Value& args) {
+        m_container.start(args);
     }
 
     void
@@ -134,6 +134,18 @@ docker_t::docker_t(context_t& context, const std::string& name, const dynamic_t&
         }
         m_image += name;
         m_tag = ""; // empty for now
+
+        if(config.count("capabilities")) {
+            auto &capabilities = config["capabilities"];
+
+            BOOST_ASSERT(capabilities.is_array());
+
+            m_additional_capabilities.SetArray();
+            for(auto it = capabilities.as_array().begin(); it != capabilities.as_array().end(); ++it) {
+                m_additional_capabilities.PushBack((*it).as_string().c_str(), m_json_allocator);
+            }
+        }
+
 
         m_network_mode = config.at("network_mode", "bridge").as_string();
 
@@ -221,20 +233,31 @@ docker_t::spawn(const std::string& path, const api::string_map_t& args, const ap
             }
         }
 
-        std::vector<std::string> binds;
-#if BOOST_VERSION >= 104600
-        std::string socket_dir(fs::path(args.at("--endpoint")).remove_filename().native().c_str());
-#else
-        std::string socket_dir(fs::path(args.at("--endpoint")).remove_filename().string().c_str());
-#endif
-        binds.emplace_back((socket_dir + ":" + m_runtime_path).c_str());
-
         // create container
         std::unique_ptr<container_handle_t> handle(
             new container_handle_t(m_docker_client.create_container(m_run_config))
         );
 
-        handle->start(binds);
+        rapidjson::Value start_args;
+        rapidjson::Value binds_json;
+
+#if BOOST_VERSION >= 104600
+        std::string socket_dir(fs::path(args.at("--endpoint")).remove_filename().native().c_str());
+#else
+        std::string socket_dir(fs::path(args.at("--endpoint")).remove_filename().string().c_str());
+#endif
+        // We should store here string pushed to RapidJson array :(
+        std::string socket_path(socket_dir + ":" + m_runtime_path);
+
+        binds_json.SetArray();
+        binds_json.PushBack(socket_path.data(), m_json_allocator);
+
+        start_args.SetObject();
+        start_args.AddMember("Binds", binds_json, m_json_allocator);
+        start_args.AddMember("CapAdd", m_additional_capabilities, m_json_allocator);
+        start_args.AddMember("NetworkMode", m_network_mode.data(), m_json_allocator);
+
+        handle->start(start_args);
         handle->attach();
 
         return std::move(handle);

--- a/docker/isolate.hpp
+++ b/docker/isolate.hpp
@@ -57,9 +57,10 @@ private:
     docker::client_t m_docker_client;
     rapidjson::Value m_run_config;
     std::string m_network_mode;
+    rapidjson::Value m_additional_capabilities;
     rapidjson::Value::AllocatorType m_json_allocator;
 };
 
-}} // namespace cocaine::storage
+}} // namespace cocaine::isolate
 
 #endif // COCAINE_DOCKER_ISOLATE_HPP

--- a/docker/isolate.hpp
+++ b/docker/isolate.hpp
@@ -56,6 +56,7 @@ private:
 
     docker::client_t m_docker_client;
     rapidjson::Value m_run_config;
+    std::string m_network_mode;
     rapidjson::Value::AllocatorType m_json_allocator;
 };
 


### PR DESCRIPTION
Some fixes from v0.11 haven't been backported yet. 
It's only the first step. I will backport support of docker remote API v.1.14.
I'll write when it's done.