### PR TITLE
[Deps] Add libboost-dev to debian/control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ FIND_PACKAGE(Boost 1.46.0
     REQUIRED COMPONENTS
         system
         filesystem
-        regex
         thread)
 
 LOCATE_LIBRARY(LIBCOCAINE "cocaine/context.hpp" "cocaine-core")

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: cmake, debhelper (>= 7.0.13), libcocaine-dev (>= 0.12.0.0),
  libswarm-dev (>= 0.6.1.0), libswarm-dev (<< 0.7),
  libnl-3-dev, libnl-genl-3-dev, libcurl4-openssl-dev (>= 7.22.0),
  libzookeeper-mt-dev,
-# mongodb-dev (<< 1:2.5.0), mongodb-dev (>= 1:2.4.9)
+# mongodb-dev (<< 1:2.5.0), mongodb-dev (>= 1:2.4.9), libboost-dev
 Standards-Version: 3.9.3
 Vcs-Git: git://github.com/cocaine/cocaine-plugins.git
 Vcs-Browser: https://github.com/cocaine/cocaine-plugins

--- a/mongo/CMakeLists.txt
+++ b/mongo/CMakeLists.txt
@@ -1,7 +1,10 @@
 FIND_PACKAGE(MongoDB)
 
+
 IF(MongoDB_FOUND)
     LOCATE_LIBRARY(LIBMONGOCLIENT "dbclient.h" "mongoclient" "mongo" "mongo/client")
+
+    FIND_PACKAGE(Boost COMPONENTS regex REQUIRED)
 
     INCLUDE_DIRECTORIES(
         ${LIBMONGOCLIENT_INCLUDE_DIRS})


### PR DESCRIPTION
Require boost regex in Mongo plugin.