### PR TITLE
Thread safety for unicorn discovery

### DIFF
--- a/unicorn/include/cocaine/cluster/unicorn.hpp
+++ b/unicorn/include/cocaine/cluster/unicorn.hpp
@@ -45,7 +45,7 @@ public:
         virtual void
         write(unicorn::api_t::response::create_result&& result);
 
-         using unicorn::writable_adapter_base_t<unicorn::api_t::response::create_result>::abort;
+        using unicorn::writable_adapter_base_t<unicorn::api_t::response::create_result>::abort;
 
         virtual void
         abort(const std::error_code& ec);

--- a/unicorn/include/cocaine/cluster/unicorn.hpp
+++ b/unicorn/include/cocaine/cluster/unicorn.hpp
@@ -125,7 +125,7 @@ private:
     asio::deadline_timer subscribe_timer;
     zookeeper::session_t zk_session;
     zookeeper::connection_t zk;
-    unicorn::zookeeper_api_t unicorn;
+    synchronized<unicorn::zookeeper_api_t> unicorn;
     synchronized<std::set<std::string>> registered_locators;
 };
 


### PR DESCRIPTION
As far as zk_api can be used from callbacks(thus possibly from other threads) make it synchronized.
Also reconnect on any kind of failure as it seems that there could be situation when zk client is permamently returning connection loss error, howevere is_unrecoverable(zk_handle) returns false.