### PR TITLE
V0.12 bleeding edge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.3.0~rc4) unstable; urgency=low
+
+  * Docker: changed dependency from lxc-docker to docker-engine (Docker 1.7.1)
+
+ -- Mikhail Kazantsev <kazan417@mail.ru>  Wed, 05 Aug 2015 00:35:12 +0700
+
 cocaine-plugins (0.12.3.0~rc3) unstable; urgency=low
 
   * Node: enable debialization.

--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Description: Cocaine - Chrono Service Development Headers
 
 Package: libcocaine-plugin-docker3
 Architecture: any
-Pre-Depends: docker-engine
+Pre-Depends: docker-engine | lxc-docker
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Cocaine - Docker Isolation
  Support of Docker for Cocaine.

--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Description: Cocaine - Chrono Service Development Headers
 
 Package: libcocaine-plugin-docker3
 Architecture: any
-Pre-Depends: lxc-docker
+Pre-Depends: docker-engine
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Cocaine - Docker Isolation
  Support of Docker for Cocaine.


### PR DESCRIPTION
fix installation docker plugin on debian. lxc-docker renamed to docker-engine in version 1.7.1