### PR TITLE
Node: error categories and its notification review.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+cocaine-plugins (0.12.3.3) unstable; urgency=low
+
+  * Node: error categories and its notification review.
+  * Now applications should keep an error code if they are in broken state.
+  * More logging added to be able to determine what's going on within isolation methods.
+  * Exceptions are now caught for cases where `async_spool` method fails immediately.
+  * Also isolate API now provides a method which gives reference to its event loop.
+
+ -- Evgeny Safronov <division494@gmail.com>  Wed, 05 Aug 2015 22:47:54 +0500
+
 cocaine-plugins (0.12.3.2) unstable; urgency=low
 
   * Docker: added cURL error category.

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(node MODULE
     src/node/balancing/load.cpp
     src/node/dispatch/client.cpp
     src/node/dispatch/worker.cpp
+    src/node/error.cpp
     src/node/manifest.cpp
     src/node/overseer.cpp
     src/node/profile.cpp

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -34,7 +34,9 @@ namespace cocaine { namespace api {
 
 struct handle_t {
     virtual
-   ~handle_t() = default;
+   ~handle_t() {
+        // Empty.
+    }
 
     virtual
     void
@@ -50,7 +52,9 @@ typedef std::map<std::string, std::string> string_map_t;
 // Cancellation token.
 struct cancellation_t {
     virtual
-   ~cancellation_t() = default;
+   ~cancellation_t() {
+        // Empty.
+    }
 
     virtual
     void
@@ -61,7 +65,9 @@ struct isolate_t {
     typedef isolate_t category_type;
 
     virtual
-   ~isolate_t() = default;
+   ~isolate_t() {
+        // Empty.
+    }
 
     virtual
     void

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -34,9 +34,7 @@ namespace cocaine { namespace api {
 
 struct handle_t {
     virtual
-   ~handle_t() {
-        // Empty.
-    }
+   ~handle_t() = default;
 
     virtual
     void
@@ -52,7 +50,7 @@ typedef std::map<std::string, std::string> string_map_t;
 // Cancellation token.
 struct cancellation_t {
     virtual
-   ~cancellation_t() {}
+   ~cancellation_t() = default;
 
     virtual
     void
@@ -62,12 +60,8 @@ struct cancellation_t {
 struct isolate_t {
     typedef isolate_t category_type;
 
-    typedef std::function<void(const std::error_code&, const std::string&)> callback_type;
-
     virtual
-   ~isolate_t() {
-        // Empty.
-    }
+   ~isolate_t() = default;
 
     virtual
     void
@@ -76,32 +70,28 @@ struct isolate_t {
     // Default implementation delegates the control flow into the blocking spool method.
     virtual
     std::unique_ptr<cancellation_t>
-    async_spool(callback_type cb) {
-        std::unique_ptr<cancellation_t> cancellation(new cancellation_t());
-
-        try {
-            spool();
-        } catch(const std::system_error& err) {
-            cb(err.code(), err.what());
-            return cancellation;
-        } catch(...) {
-            cb(std::make_error_code(std::errc::io_error), "Unknown");
-            return cancellation;
-        }
-
-        cb(std::error_code(), "");
-
-        return cancellation;
+    async_spool(std::function<void(const std::error_code&)> handler) {
+        spool();
+        get_io_service().post(std::bind(handler, std::error_code()));
+        return std::make_unique<cancellation_t>();
     }
 
     virtual
     std::unique_ptr<handle_t>
     spawn(const std::string& path, const string_map_t& args, const string_map_t& environment) = 0;
 
-protected:
-    isolate_t(context_t&, asio::io_service&, const std::string& /* name */, const dynamic_t& /* args */) {
-        // Empty.
+    asio::io_service&
+    get_io_service() {
+        return io_service;
     }
+
+protected:
+    isolate_t(context_t&, asio::io_service& io_service, const std::string&, const dynamic_t& /* args */):
+        io_service(io_service)
+    {}
+
+private:
+    asio::io_service& io_service;
 };
 
 template<>

--- a/node/include/cocaine/detail/service/node/app.hpp
+++ b/node/include/cocaine/detail/service/node/app.hpp
@@ -6,13 +6,9 @@
 #include "cocaine/idl/node.hpp"
 #include "cocaine/rpc/slot/deferred.hpp"
 
-namespace cocaine {
-    namespace service {
-        namespace node {
-            class app_state_t;
-        } // namespace node
-    } // namespace service
-} // namespace cocaine
+namespace cocaine { namespace service { namespace node {
+    class app_state_t;
+}}} // namespace cocaine::service::node
 
 namespace cocaine { namespace service { namespace node {
 
@@ -32,7 +28,6 @@ public:
     std::string
     name() const;
 
-    // WARNING: Unstable - just added.
     dynamic_t
     info(io::node::info::flags_t flags) const;
 };

--- a/node/include/cocaine/idl/node.hpp
+++ b/node/include/cocaine/idl/node.hpp
@@ -193,11 +193,25 @@ namespace cocaine { namespace error {
 enum node_errors {
     deadline_error = 1,
     resource_error,
-    timeout_error
+    timeout_error,
+
+    /// App has been already started.
+    already_started,
+
+    /// App is not running.
+    not_running,
+
+    /// The isolate plugin has failed its contract and has thrown non `system_error` exception.
+    /// Checking logs may help to determine what was happened.
+    uncaught_spool_error,
+    uncaught_publish_error,
 };
 
-auto
-make_error_code(node_errors code) -> std::error_code;
+const std::error_category&
+node_category();
+
+std::error_code
+make_error_code(node_errors code);
 
 }} // namespace cocaine::error
 
@@ -206,7 +220,7 @@ namespace std {
 template<>
 struct is_error_code_enum<cocaine::error::node_errors>:
     public true_type
-{ };
+{};
 
 } // namespace std
 

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -120,7 +120,7 @@ class stopped_t:
     std::error_code ec;
 
 public:
-    stopped_t() noexcept = default;
+    stopped_t() noexcept {}
 
     explicit
     stopped_t(std::error_code ec) noexcept:

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -117,16 +117,14 @@ public:
 class stopped_t:
     public base_t
 {
-    std::string cause;
+    std::error_code ec;
 
 public:
-    stopped_t() noexcept:
-        cause("uninitialized")
-    {}
+    stopped_t() noexcept = default;
 
     explicit
-    stopped_t(std::string cause) noexcept:
-        cause(std::move(cause))
+    stopped_t(std::error_code ec) noexcept:
+        ec(std::move(ec))
     {}
 
     virtual
@@ -139,8 +137,10 @@ public:
     dynamic_t::object_t
     info(io::node::info::flags_t) const {
         dynamic_t::object_t info;
-        info["state"] = "stopped";
-        info["cause"] = cause;
+        info["state"] = ec ? std::string("broken") : "stopped";
+        info["error"] = ec.value();
+        info["cause"] = ec ? ec.message() : "manually stopped";
+
         return info;
     }
 };
@@ -154,7 +154,13 @@ class spooling_t:
 
 public:
     template<class F>
-    spooling_t(context_t& context, asio::io_service& loop, const manifest_t& manifest, const profile_t& profile, F cb) {
+    spooling_t(context_t& context,
+               asio::io_service& loop,
+               const manifest_t& manifest,
+               const profile_t& profile,
+               const logging::log_t* log,
+               F handler)
+    {
         isolate = context.get<api::isolate_t>(
             profile.isolate.type,
             context,
@@ -163,12 +169,24 @@ public:
             profile.isolate.args
         );
 
-        spooler = isolate->async_spool(std::move(cb));
+        try {
+            // NOTE: Regardless of whether the asynchronous operation completes immediately or not,
+            // the handler will not be invoked from within this call. Invocation of the handler
+            // will be performed in a manner equivalent to using `boost::asio::io_service::post()`.
+            spooler = isolate->async_spool(handler);
+        } catch (const std::system_error& err) {
+            COCAINE_LOG_ERROR(log, "uncaught spool exception: [%d] %s", err.code().value(), err.code().message());
+            handler(err.code());
+        } catch (const std::exception& err) {
+            COCAINE_LOG_ERROR(log, "uncaught spool exception: %s", err.what());
+            handler(error::uncaught_spool_error);
+        }
     }
 
     ~spooling_t() {
-        // TODO: Check lifetimes.
-        spooler->cancel();
+        if (spooler) {
+            spooler->cancel();
+        }
     }
 
     virtual
@@ -350,35 +368,34 @@ public:
                 *loop,
                 manifest(),
                 profile,
-                std::bind(&app_state_t::on_spool, shared_from_this(), ph::_1, ph::_2)
+                log.get(),
+                std::bind(&app_state_t::on_spool, shared_from_this(), ph::_1)
             ));
         });
     }
 
     void
-    cancel(std::string cause = "manually stopped") {
-        state.synchronize()->reset(new state::stopped_t(std::move(cause)));
+    cancel(std::error_code ec) {
+        state.synchronize()->reset(new state::stopped_t(std::move(ec)));
     }
 
 private:
     void
-    on_spool(const std::error_code& ec, const std::string& what) {
+    on_spool(const std::error_code& ec) {
         if (ec) {
-            const auto reason = what.empty() ? ec.message() : what;
+            COCAINE_LOG_ERROR(log, "unable to spool app - [%d] %s", ec.value(), ec.message());
 
-            COCAINE_LOG_ERROR(log, "unable to spool app - [%d] %s", ec.value(), reason);
-
-            loop->dispatch(std::bind(&app_state_t::cancel, shared_from_this(), reason));
+            loop->dispatch(std::bind(&app_state_t::cancel, shared_from_this(), ec));
 
             // Attempt to finish node service's request.
             try {
-                deferred.abort(ec, reason);
+                deferred.abort(ec, ec.message());
             } catch (const std::exception&) {
                 // Ignore if the client has been disconnected.
             }
         } else {
             // Dispatch the completion handler to be sure it will be called in a I/O thread to
-            // avoid possible deadlocks (which ones?).
+            // avoid possible deadlocks.
             loop->dispatch(std::bind(&app_state_t::publish, shared_from_this()));
         }
     }
@@ -389,9 +406,16 @@ private:
             state.synchronize()->reset(
                 new state::running_t(context, manifest(), profile, log.get(), loop)
             );
+        } catch (const std::system_error& err) {
+            COCAINE_LOG_ERROR(log, "unable to publish app: [%d] %s", err.code().value(), err.code().message());
+            cancel(err.code());
+            deferred.abort(err.code(), err.code().message());
+            return;
         } catch (const std::exception& err) {
             COCAINE_LOG_ERROR(log, "unable to publish app: %s", err.what());
-            cancel(err.what());
+            cancel(error::uncaught_publish_error);
+            deferred.abort(error::uncaught_publish_error);
+            return;
         }
 
         // Attempt to finish node service's request.
@@ -413,7 +437,7 @@ app_t::app_t(context_t& context,
 }
 
 app_t::~app_t() {
-    state->cancel();
+    state->cancel(std::error_code());
 }
 
 std::string

--- a/node/src/node/error.cpp
+++ b/node/src/node/error.cpp
@@ -1,0 +1,59 @@
+#include "cocaine/idl/node.hpp"
+
+namespace {
+
+// Node Service errors
+
+struct node_category_t:
+    public std::error_category
+{
+    virtual
+    const char*
+    name() const noexcept {
+        return "node category";
+    }
+
+    virtual
+    std::string
+    message(int ec) const {
+        using cocaine::error::node_errors;
+
+        switch (ec) {
+        case node_errors::deadline_error:
+            return "invocation deadline has passed";
+        case node_errors::resource_error:
+            return "no resources available to complete invocation";
+        case node_errors::timeout_error:
+            return "invocation has timed out";
+        case node_errors::already_started:
+            return "application has already been started";
+        case node_errors::not_running:
+            return "application is not running";
+        case node_errors::uncaught_spool_error:
+            return "uncaught error while spooling app";
+        case node_errors::uncaught_publish_error:
+            return "uncaught error while publishing app";
+        default:
+            break;
+        }
+
+        return "unknown node error " + std::to_string(ec);
+    }
+};
+
+} // namespace
+
+namespace cocaine { namespace error {
+
+const std::error_category&
+node_category() {
+    static node_category_t category;
+    return category;
+}
+
+std::error_code
+make_error_code(node_errors code) {
+    return std::error_code(static_cast<int>(code), node_category());
+}
+
+}} // namespace cocaine::error


### PR DESCRIPTION
 - Now applications should keep an error code if they are in broken state.
 - More logging added to be able to determine what's going on within isolation methods.
 - Exceptions are now caught for cases where `async_spool` method fails immediately.
 - Also isolate API now provides a method which gives reference to its event loop.

@kobolog @noxiouz @antmat ptal