### PR TITLE
Fix(process): close all opened file descriptors after fork.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.3.27) unstable; urgency=low
+
+  * Fix(process): close all file descriptors after fork.
+
+ -- Evgeny Safronov <division494@gmail.com>  Mon, 28 Sep 2015 19:00:32 +0300
+
 cocaine-plugins (0.12.3.26) unstable; urgency=low
 
   * Fix(chrono): fixed deadlock.

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -434,8 +434,8 @@ closefrom_dir(boost::filesystem::path path) {
 
 static void
 close_all() {
-    // FreeBSD has `closefrom` syscall, but we don't. The only effective solution is to iterate over
-    // procfs entries.
+    // FreeBSD has `closefrom` syscall, but we haven't. The only effective solution is to iterate
+    // over procfs entries.
 
 #if defined(__linux__)
     closefrom_dir("/proc/self/fd/");

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -407,6 +407,9 @@ closefrom_dir(boost::filesystem::path path) {
 
     std::vector<int> fds;
 
+    // Allocate at lease PAGE_SIZE bytes to prevent frequent reallocations.
+    fds.reserve(::getpagesize());
+
     const boost::filesystem::directory_iterator end;
     for (const auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(path), end)) {
         const auto filename = entry.path().filename().native();


### PR DESCRIPTION
This PR should prepare the child process with cleaning up its all opened descriptors.

Since we've forked there can't be new file descriptors opened unless we create some while closing.

I ask for strong review, because I never used `dirent` API and could miss something.

@kobolog @antmat @noxiouz PTAL.