### PR TITLE
fixed `throw error_t`

### DIFF
--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -203,7 +203,7 @@ public:
 
     std::shared_ptr<overseer_t>
     overseer() const {
-        throw error_t("invalid state");
+        throw cocaine::error_t("invalid state");
     }
 };
 


### PR DESCRIPTION
Cannot compile node plugin:
```
Scanning dependencies of target node
[ 25%] Building CXX object node/CMakeFiles/node.dir/src/isolate/process.cpp.o
[ 27%] Building CXX object node/CMakeFiles/node.dir/src/isolate/process/archive.cpp.o
[ 29%] Building CXX object node/CMakeFiles/node.dir/src/isolate/process/spooler.cpp.o
[ 31%] Building CXX object node/CMakeFiles/node.dir/src/module.cpp.o
[ 34%] Building CXX object node/CMakeFiles/node.dir/src/node.cpp.o
[ 36%] Building CXX object node/CMakeFiles/node.dir/src/node/app.cpp.o
/var/chef/cache/cocaine-plugins/node/src/node/app.cpp: In member function ‘std::shared_ptr<cocaine::overseer_t> state::base_t::overseer() const’:
/var/chef/cache/cocaine-plugins/node/src/node/app.cpp:206:15: error: reference to ‘error_t’ is ambiguous
         throw error_t("invalid state");
               ^
In file included from /usr/include/c++/4.8/cerrno:41:0,
                 from /usr/include/c++/4.8/ext/string_conversions.h:44,
                 from /usr/include/c++/4.8/bits/basic_string.h:2815,
                 from /usr/include/c++/4.8/string:52,
                 from /var/chef/cache/cocaine-plugins/node/include/cocaine/detail/service/node/app.hpp:3,
                 from /var/chef/cache/cocaine-plugins/node/src/node/app.cpp:1:
/usr/include/errno.h:68:13: note: candidates are: typedef int error_t
 typedef int error_t;
             ^
In file included from /usr/include/cocaine/common.hpp:54:0,
                 from /var/chef/cache/cocaine-plugins/node/include/cocaine/detail/service/node/app.hpp:5,
                 from /var/chef/cache/cocaine-plugins/node/src/node/app.cpp:1:
/usr/include/cocaine/errors.hpp:99:8: note:                 struct cocaine::error::error_t
 struct error_t:
        ^
/var/chef/cache/cocaine-plugins/node/src/node/app.cpp:207:5: warning: no return statement in function returning non-void [-Wreturn-type]
     }
     ^
make[2]: *** [node/CMakeFiles/node.dir/src/node/app.cpp.o] Error 1
make[1]: *** [node/CMakeFiles/node.dir/all] Error 2
make: *** [all] Error 2
```